### PR TITLE
Add support for groups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const propTypes    = {
     onBlur         : React.PropTypes.func.isRequired,
     onFocus        : React.PropTypes.func.isRequired,
     renderOption   : React.PropTypes.func.isRequired,
+    renderHeading  : React.PropTypes.func.isRequired,
     value          : React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.array
@@ -40,6 +41,9 @@ const defaultProps = {
     onFocus        : function () {},
     onChange       : function () {},
     renderOption   : function (option) {
+        return option.name;
+    },
+    renderHeading  : function (option) {
         return option.name;
     },
     fuse: {
@@ -497,11 +501,10 @@ class Component extends React.Component {
 
     }
 
-    renderOptions() {
+    renderOptions(items) {
         let select       = null;
         let options      = [];
-        let selectStyle  = {};
-        let foundOptions = this.state.options;
+        let foundOptions = items || this.state.options;
 
         if (foundOptions && foundOptions.length > 0) {
             foundOptions.forEach((element, i) => {
@@ -516,9 +519,17 @@ class Component extends React.Component {
                     className += ' ' + Bem.m(this.classes.option, 'selected');
                 }
 
+                let content;
+                let extra;
+
                 if (element.type && element.type === 'heading') {
                     className = this.classes.heading;
+
+                    content = this.props.renderHeading(element, this.state, this.props);
+                    extra = this.renderOptions(element.items);
                 } else {
+                    content = this.props.renderOption(element, this.state, this.props);
+
                     if (this.props.multiple) {
                         if (this.state.value.indexOf(element.value) < 0) {
                             onClick = this.chooseOption.bind(this, element.value);
@@ -537,9 +548,13 @@ class Component extends React.Component {
                     onClick={onClick}
                     key={element.value + '-option'}
                     data-value={element.value}
-                >{this.props.renderOption(element, this.state, this.props)}</li>
+                >{content}</li>
 
                 options.push(li);
+
+                if (extra) {
+                    options.push(extra);
+                }
             });
 
             if (options.length > 0) {
@@ -551,11 +566,16 @@ class Component extends React.Component {
             }
         }
 
+                return select;
+        }
+
+        renderSelect() {
+        let selectStyle  = {};
+        let className = this.classes.select;
+
         if (this.props.multiple) {
             selectStyle.height = this.props.height;
         }
-
-        let className = this.classes.select;
 
         if (this.state.focus) {
             className += ' ' + Bem.m(this.classes.select, 'display');
@@ -563,7 +583,7 @@ class Component extends React.Component {
 
         return (
             <div ref="select" className={className} style={selectStyle}>
-                {select}
+                {this.renderOptions()}
             </div>
         );
     }
@@ -645,7 +665,7 @@ class Component extends React.Component {
             <div className={className} ref="container">
                 {this.renderOutElement()}
                 {this.renderSearchField()}
-                {this.renderOptions()}
+                {this.renderSelect()}
             </div>
         );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class Component extends React.Component {
             select    : Bem.e(this.props.className, 'select'),
             options   : Bem.e(this.props.className, 'options'),
             option    : Bem.e(this.props.className, 'option'),
-            heading   : Bem.e(this.props.className, 'heading'),
+            group     : Bem.e(this.props.className, 'group'),
             out       : Bem.e(this.props.className, 'out'),
             label     : Bem.e(this.props.className, 'label'),
             focus     : (this.props.multiple) ? this.props.className + ' ' + Bem.m(this.props.className, 'multiple focus') : this.props.className + ' ' + Bem.m(this.props.className, 'focus')
@@ -522,8 +522,8 @@ class Component extends React.Component {
                 let content;
                 let extra;
 
-                if (element.type && element.type === 'heading') {
-                    className = this.classes.heading;
+                if (element.type && element.type === 'group') {
+                    className = this.classes.group;
 
                     content = this.props.renderHeading(element, this.state, this.props);
                     extra = this.renderOptions(element.items);

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ class Component extends React.Component {
             select    : Bem.e(this.props.className, 'select'),
             options   : Bem.e(this.props.className, 'options'),
             option    : Bem.e(this.props.className, 'option'),
+            heading   : Bem.e(this.props.className, 'heading'),
             out       : Bem.e(this.props.className, 'out'),
             label     : Bem.e(this.props.className, 'label'),
             focus     : (this.props.multiple) ? this.props.className + ' ' + Bem.m(this.props.className, 'multiple focus') : this.props.className + ' ' + Bem.m(this.props.className, 'focus')
@@ -515,15 +516,19 @@ class Component extends React.Component {
                     className += ' ' + Bem.m(this.classes.option, 'selected');
                 }
 
-                if (this.props.multiple) {
-                    if (this.state.value.indexOf(element.value) < 0) {
-                        onClick = this.chooseOption.bind(this, element.value);
-                    } else {
-                        onClick= this.removeOption.bind(this, element.value);
-                    }
+                if (element.type && element.type === 'heading') {
+                    className = this.classes.heading;
                 } else {
-                    if (element.value !== this.state.value) {
-                        onClick = this.chooseOption.bind(this, element.value);
+                    if (this.props.multiple) {
+                        if (this.state.value.indexOf(element.value) < 0) {
+                            onClick = this.chooseOption.bind(this, element.value);
+                        } else {
+                            onClick= this.removeOption.bind(this, element.value);
+                        }
+                    } else {
+                        if (element.value !== this.state.value) {
+                            onClick = this.chooseOption.bind(this, element.value);
+                        }
                     }
                 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -505,6 +505,7 @@ class Component extends React.Component {
         if (foundOptions && foundOptions.length > 0) {
             foundOptions.forEach((element, i) => {
                 let className = this.classes.option;
+                let onClick = null;
 
                 if (this.state.highlighted === i) {
                     className += ' ' + Bem.m(this.classes.option, 'hover');
@@ -516,17 +517,24 @@ class Component extends React.Component {
 
                 if (this.props.multiple) {
                     if (this.state.value.indexOf(element.value) < 0) {
-                        options.push(<li className={className} onClick={this.chooseOption.bind(this, element.value)} key={element.value + '-option'} data-value={element.value}>{this.props.renderOption(element, this.state, this.props)}</li>);
+                        onClick = this.chooseOption.bind(this, element.value);
                     } else {
-                        options.push(<li className={className} onClick={this.removeOption.bind(this, element.value)} key={element.value + '-option'} data-value={element.value}>{this.props.renderOption(element, this.state, this.props)}</li>);
+                        onClick= this.removeOption.bind(this, element.value);
                     }
                 } else {
-                    if (element.value === this.state.value) {
-                        options.push(<li className={className} key={element.value + '-option'} data-value={element.value}>{this.props.renderOption(element)}</li>);
-                    } else {
-                        options.push(<li className={className} onClick={this.chooseOption.bind(this, element.value)} key={element.value + '-option'} data-value={element.value}>{this.props.renderOption(element, this.state, this.props)}</li>);
+                    if (element.value !== this.state.value) {
+                        onClick = this.chooseOption.bind(this, element.value);
                     }
                 }
+
+                const li = <li
+                    className={className}
+                    onClick={onClick}
+                    key={element.value + '-option'}
+                    data-value={element.value}
+                >{this.props.renderOption(element, this.state, this.props)}</li>
+
+                options.push(li);
             });
 
             if (options.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ const defaultProps = {
         return option.name;
     },
     fuse: {
-        keys      : ['name'],
+        keys      : ['name', 'items.name'],
         threshold : 0.3
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,7 @@ class Component extends React.Component {
     }
 
     findByValue(source, value) {
-        if (!source || source.length < 1) {
+        if (!source) {
             source = this.state.defaultOptions;
         }
 
@@ -366,9 +366,17 @@ class Component extends React.Component {
             return null;
         }
 
-        return source.filter(function (object) {
-            return object.value === value;
-        })[0];
+        for (const object of source) {
+            if (object.type === 'group') {
+                const result = this.findByValue(object.items, value);
+
+                if (result) {
+                    return object;
+                }
+            } else if (object.value === value) {
+                return value;
+            }
+        }
     }
 
     toggle() {

--- a/src/index.js
+++ b/src/index.js
@@ -371,10 +371,10 @@ class Component extends React.Component {
                 const result = this.findByValue(object.items, value);
 
                 if (result) {
-                    return object;
+                    return result;
                 }
             } else if (object.value === value) {
-                return value;
+                return object;
             }
         }
     }


### PR DESCRIPTION
It is a bit hacky, if I find some time I can improved, if you'd like to have this feature :)

Basically right now you'd need to pass a "fake" option, with `type: 'heading'` to make it work.

I haven't handled keyboard support yet

EDIT:

Instead of passing headiing as a type we use group, similar to react-dropdown.

**TODO**

- [ ] filter sub items
- [ ] improve rendering code
- [ ] support for keyboard