### PR TITLE
Fetch icons via HTTPS not HTTP

### DIFF
--- a/example.css
+++ b/example.css
@@ -1,4 +1,4 @@
-@import 'http://weloveiconfonts.com/api/?family=fontawesome';
+@import 'https://weloveiconfonts.com/api/?family=fontawesome';
 
 [class*="fontawesome-"]:before {
     font-family: 'fontawesome', sans-serif;


### PR DESCRIPTION
Github Pages forces HTTPS, and my browser prevents loading unsecure resources within an HTTPS page. This fixes that.