### PR TITLE
fix: Issue when searching and pressing the enter key

### DIFF
--- a/__tests__/useSelect.test.jsx
+++ b/__tests__/useSelect.test.jsx
@@ -36,5 +36,24 @@ describe('Test SelectSearch component', () => {
             searching: false,
             search: '',
         });
+	});
+
+	test('Renders without value present', () => {
+        const flatOptions = flattenOptions(friends);
+        const groupedOptions = groupOptions(flatOptions);
+        const initialOption = flatOptions[1];
+        const wrapper = mount(<CustomSelect options={friends} value={undefined} />);
+        const output = wrapper.find('div').props();
+
+        expect(output.snapshot).toStrictEqual({
+            value: null,
+            highlighted: -1,
+            options: groupedOptions,
+            disabled: false,
+            displayValue: "",
+            focus: false,
+            searching: false,
+            search: '',
+        });
     });
 });

--- a/src/useSelect.js
+++ b/src/useSelect.js
@@ -77,7 +77,9 @@ export default function useSelectSearch({
     const onFocus = () => setFocus(true);
     const onSelect = useCallback((val) => {
         setState((oldState) => {
-            const item = val || oldState.flat[oldState.highlighted].value;
+            const defaultItem = oldState.flat[oldState.highlighted];
+            const oldStateValue = defaultItem && defaultItem.value;
+            const item = val || oldStateValue;
             const values = getNewValue(item, oldState.value, multiple);
             const newOptions = getOption(values, oldState.flat);
 


### PR DESCRIPTION
When pressing the enter key on a search for causes and error to occur.

It also happens in this example.
https://react-select-search.com/?path=/story/multiple-select--search

```
TypeError: Cannot read property 'value' of undefined
    at https://react-select-search.com/main.2a55b59e5151045cfaee.bundle.js:1:99508
    at vh (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:621395)
    at wh (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:622161)
    at Object.useState (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:626190)
    at exports.useState (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:562361)
    at useSelectSearch (https://react-select-search.com/main.2a55b59e5151045cfaee.bundle.js:1:97645)
    at https://react-select-search.com/main.2a55b59e5151045cfaee.bundle.js:1:82806
    at oh (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:620601)
    at Zh (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:628499)
    at Rj (https://react-select-search.com/vendors~main.2a55b59e5151045cfaee.bundle.js:2:668795)
```

Thank you for this tool it is very helpful!