### PR TITLE
Publish types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *
 !dist/**/*
 !package.json
+!src/index.d.ts

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Lightweight select component for React",
   "main": "dist/esm/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "lint": "eslint src/* --ext .js --ext .jsx",
     "test": "jest",


### PR DESCRIPTION
The type definitions added in https://github.com/tbleckert/react-select-search/pull/73 aren't actually available to users. They're not included in the bundle and missing from the package.json.

This PR addresses that.