### PR TITLE
Update documentation regarding IE11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,11 @@ function getOptions(query) {
 The function runs on each search query update, so you might want to throttle the fetches.
 If you return a promise, the class `is-searching` will be applied to the main element, giving you a chance
 to change the appearance, like adding a spinner. The property `searching` is also available in the snapshot that is sent to your render callbacks.
+
+## IE11 support
+
+The main build is an ES module and targets modern browsers. In particular, it specifically excludes IE11 in the build process. If you need to support IE11, you should require the CommonJS build instead like so
+
+```js
+import SelectSearch from 'react-select-search/dist/cjs/index.js';
+```


### PR DESCRIPTION
Thank you @tbleckert for this awesome lib. Unfortunately, the lack of IE11 support out of the box tripped me up. As mentioned https://github.com/tbleckert/react-select-search/issues/96, it might be a good idea to document how to use this lib with IE11 support to avoid any unexpected issues.

This adds a section in the README highlighting the need to use the CommonJS build for IE11 support, instead of the default (ESM) build which specifically excludes IE11 support.