### PR TITLE
Add empty message for option list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Below is all the available options you can pass to the component. Options withou
 | value | string, array | undefined | The value should be an array if multiple mode. |
 | multiple | boolean | false | Set to true if you want to allow multiple selected options. |
 | search | boolean | false | Set to true to enable search functionality |
+| emptyMessage | string, function | null | Set empty message for empty options list, you can provide render function without arguments instead plain string message|
 | disabled | boolean | false | Disables all functionality |
 | placeholder | string | empty string | Displayed if no option is selected and/or when search field is focused with empty value. |
 | autoComplete | string, on/off | off | Disables/Enables autoComplete functionality in search field. |

--- a/__tests__/SelectSearch.test.jsx
+++ b/__tests__/SelectSearch.test.jsx
@@ -73,6 +73,36 @@ describe('Test SelectSearch component', () => {
         expect(tree).toMatchSnapshot();
     });
 
+    test('Renders with empty message string', () => {
+        const tree = renderer.create((
+            <SelectSearch
+                options={[
+                    { value: 'foo', name: 'Foo' },
+                    { value: 'bar', name: 'Bar' },
+                ]}
+                search
+                emptyMessage="Not found"
+            />
+        )).toJSON();
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('Renders with empty message renderer', () => {
+        const tree = renderer.create((
+            <SelectSearch
+                options={[
+                    { value: 'foo', name: 'Foo' },
+                    { value: 'bar', name: 'Bar' },
+                ]}
+                search
+                emptyMessage={() => <div>Not found</div>}
+            />
+        )).toJSON();
+
+        expect(tree).toMatchSnapshot();
+    });
+
     test('Renders with search and placeholder', () => {
         const tree = renderer.create((
             <SelectSearch options={[

--- a/__tests__/__snapshots__/SelectSearch.test.jsx.snap
+++ b/__tests__/__snapshots__/SelectSearch.test.jsx.snap
@@ -2073,6 +2073,64 @@ exports[`Test SelectSearch component Renders with disabled 1`] = `
 </div>
 `;
 
+exports[`Test SelectSearch component Renders with empty message renderer 1`] = `
+<div
+  className="select-search"
+  id={null}
+>
+  <div
+    className="select-search__value"
+  >
+    <input
+      autoComplete="on"
+      autoFocus={false}
+      className="select-search__input"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      placeholder={null}
+      readOnly={false}
+      tabIndex="0"
+      value="Foo"
+    />
+  </div>
+</div>
+`;
+
+exports[`Test SelectSearch component Renders with empty message string 1`] = `
+<div
+  className="select-search"
+  id={null}
+>
+  <div
+    className="select-search__value"
+  >
+    <input
+      autoComplete="on"
+      autoFocus={false}
+      className="select-search__input"
+      disabled={false}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      placeholder={null}
+      readOnly={false}
+      tabIndex="0"
+      value="Foo"
+    />
+  </div>
+</div>
+`;
+
 exports[`Test SelectSearch component Renders with multiple 1`] = `
 <div
   className="select-search"

--- a/dist/cjs/SelectSearch.js
+++ b/dist/cjs/SelectSearch.js
@@ -47,7 +47,8 @@ var SelectSearch = /*#__PURE__*/(0, _react.forwardRef)(function (_ref, ref) {
       renderOption = _ref.renderOption,
       renderGroupHeader = _ref.renderGroupHeader,
       getOptions = _ref.getOptions,
-      fuse = _ref.fuse;
+      fuse = _ref.fuse,
+      emptyMessage = _ref.emptyMessage;
   var selectRef = (0, _react.useRef)(null);
 
   var _useSelect = (0, _useSelect2["default"])({
@@ -89,6 +90,15 @@ var SelectSearch = /*#__PURE__*/(0, _react.forwardRef)(function (_ref, ref) {
 
     return className.split(' ')[0] + "__" + key;
   }, [className]);
+  var renderEmptyMessage = (0, _react.useCallback)(function () {
+    if (typeof emptyMessage === 'function') {
+      return emptyMessage();
+    } else if (typeof emptyMessage === 'string') {
+      return /*#__PURE__*/_react["default"].createElement("li", null, emptyMessage);
+    }
+
+    return null;
+  }, emptyMessage);
   var wrapperClass = [cls('container'), disabled ? cls('is-disabled') : false, searching ? cls('is-loading') : false, focus ? cls('has-focus') : false].filter(function (single) {
     return !!single;
   }).join(' ');
@@ -145,7 +155,7 @@ var SelectSearch = /*#__PURE__*/(0, _react.forwardRef)(function (_ref, ref) {
     ref: selectRef
   }, /*#__PURE__*/_react["default"].createElement("ul", {
     className: cls('options')
-  }, options.map(function (option) {
+  }, options.length > 0 ? options.map(function (option) {
     var isGroup = option.type === 'group';
     var items = isGroup ? option.items : [option];
     var base = {
@@ -176,7 +186,7 @@ var SelectSearch = /*#__PURE__*/(0, _react.forwardRef)(function (_ref, ref) {
     }
 
     return rendered;
-  }))));
+  }) : renderEmptyMessage() || null)));
 });
 SelectSearch.defaultProps = {
   className: 'select-search',
@@ -212,7 +222,8 @@ SelectSearch.defaultProps = {
     keys: ['name', 'groupName'],
     threshold: 0.3
   },
-  getOptions: null
+  getOptions: null,
+  emptyMessage: null
 };
 SelectSearch.propTypes = process.env.NODE_ENV !== "production" ? {
   options: _propTypes["default"].arrayOf(_types.optionType).isRequired,
@@ -235,7 +246,8 @@ SelectSearch.propTypes = process.env.NODE_ENV !== "production" ? {
   fuse: _propTypes["default"].oneOfType([_propTypes["default"].bool, _propTypes["default"].shape({
     keys: _propTypes["default"].arrayOf(_propTypes["default"].string),
     threshold: _propTypes["default"].number
-  })])
+  })]),
+  emptyMessage: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].func])
 } : {};
 
 var _default = /*#__PURE__*/(0, _react.memo)(SelectSearch);

--- a/dist/esm/SelectSearch.js
+++ b/dist/esm/SelectSearch.js
@@ -30,7 +30,8 @@ const SelectSearch = /*#__PURE__*/forwardRef(({
   renderOption,
   renderGroupHeader,
   getOptions,
-  fuse
+  fuse,
+  emptyMessage
 }, ref) => {
   const selectRef = useRef(null);
   const [snapshot, valueProps, optionProps] = useSelect({
@@ -70,6 +71,15 @@ const SelectSearch = /*#__PURE__*/forwardRef(({
 
     return className.split(' ')[0] + "__" + key;
   }, [className]);
+  const renderEmptyMessage = useCallback(() => {
+    if (typeof emptyMessage === 'function') {
+      return emptyMessage();
+    } else if (typeof emptyMessage === 'string') {
+      return /*#__PURE__*/React.createElement("li", null, emptyMessage);
+    }
+
+    return null;
+  }, emptyMessage);
   const wrapperClass = [cls('container'), disabled ? cls('is-disabled') : false, searching ? cls('is-loading') : false, focus ? cls('has-focus') : false].filter(single => !!single).join(' ');
   const inputValue = focus && search ? searchValue : displayValue;
   useEffect(() => {
@@ -126,7 +136,7 @@ const SelectSearch = /*#__PURE__*/forwardRef(({
     ref: selectRef
   }, /*#__PURE__*/React.createElement("ul", {
     className: cls('options')
-  }, options.map(option => {
+  }, options.length > 0 ? options.map(option => {
     const isGroup = option.type === 'group';
     const items = isGroup ? option.items : [option];
     const base = {
@@ -155,7 +165,7 @@ const SelectSearch = /*#__PURE__*/forwardRef(({
     }
 
     return rendered;
-  }))));
+  }) : renderEmptyMessage() || null)));
 });
 SelectSearch.defaultProps = {
   className: 'select-search',
@@ -184,7 +194,8 @@ SelectSearch.defaultProps = {
     keys: ['name', 'groupName'],
     threshold: 0.3
   },
-  getOptions: null
+  getOptions: null,
+  emptyMessage: null
 };
 SelectSearch.propTypes = process.env.NODE_ENV !== "production" ? {
   options: PropTypes.arrayOf(optionType).isRequired,
@@ -207,6 +218,7 @@ SelectSearch.propTypes = process.env.NODE_ENV !== "production" ? {
   fuse: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({
     keys: PropTypes.arrayOf(PropTypes.string),
     threshold: PropTypes.number
-  })])
+  })]),
+  emptyMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
 } : {};
 export default /*#__PURE__*/memo(SelectSearch);

--- a/src/SelectSearch.jsx
+++ b/src/SelectSearch.jsx
@@ -30,6 +30,7 @@ const SelectSearch = forwardRef(({
     renderGroupHeader,
     getOptions,
     fuse,
+    emptyMessage
 }, ref) => {
     const selectRef = useRef(null);
     const [snapshot, valueProps, optionProps] = useSelect({
@@ -71,6 +72,16 @@ const SelectSearch = forwardRef(({
 
         return `${className.split(' ')[0]}__${key}`;
     }, [className]);
+
+    const renderEmptyMessage = useCallback(() => {
+        if (typeof emptyMessage === 'function') {
+            return emptyMessage();
+        } else if (typeof emptyMessage === 'string') {
+            return <li>{emptyMessage}</li>
+        }
+
+        return null;
+    }, emptyMessage);
 
     const wrapperClass = [
         cls('container'),
@@ -136,35 +147,37 @@ const SelectSearch = forwardRef(({
             {shouldRenderOptions && (
                 <div className={cls('select')} ref={selectRef}>
                     <ul className={cls('options')}>
-                        {options.map((option) => {
-                            const isGroup = option.type === 'group';
-                            const items = (isGroup) ? option.items : [option];
-                            const base = { cls, optionProps, renderOption };
-                            const rendered = items.map((o) => (
-                                <Option
-                                    key={o.value}
-                                    selected={isSelected(o, value)}
-                                    highlighted={highlighted === o.index}
-                                    {...base}
-                                    {...o}
-                                />
-                            ));
+                        {options.length > 0 ? (
+                            options.map((option) => {
+                                const isGroup = option.type === 'group';
+                                const items = (isGroup) ? option.items : [option];
+                                const base = { cls, optionProps, renderOption };
+                                const rendered = items.map((o) => (
+                                    <Option
+                                        key={o.value}
+                                        selected={isSelected(o, value)}
+                                        highlighted={highlighted === o.index}
+                                        {...base}
+                                        {...o}
+                                    />
+                                ));
 
-                            if (isGroup) {
-                                return (
-                                    <li role="none" className={cls('row')} key={option.groupId}>
-                                        <div className={cls('group')}>
-                                            <div className={cls('group-header')}>{renderGroupHeader(option.name)}</div>
-                                            <ul className={cls('options')}>
-                                                {rendered}
-                                            </ul>
-                                        </div>
-                                    </li>
-                                );
-                            }
+                                if (isGroup) {
+                                    return (
+                                        <li role="none" className={cls('row')} key={option.groupId}>
+                                            <div className={cls('group')}>
+                                                <div className={cls('group-header')}>{renderGroupHeader(option.name)}</div>
+                                                <ul className={cls('options')}>
+                                                    {rendered}
+                                                </ul>
+                                            </div>
+                                        </li>
+                                    );
+                                }
 
-                            return rendered;
-                        })}
+                                return rendered;
+                            })
+                        ) : (renderEmptyMessage() || null)}
                     </ul>
                 </div>
             )}
@@ -203,6 +216,7 @@ SelectSearch.defaultProps = {
         threshold: 0.3,
     },
     getOptions: null,
+    emptyMessage: null,
 };
 
 SelectSearch.propTypes = {
@@ -240,6 +254,10 @@ SelectSearch.propTypes = {
             threshold: PropTypes.number,
         }),
     ]),
+    emptyMessage: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func
+    ])
 };
 
 export default memo(SelectSearch);

--- a/stories/0-Single.stories.js
+++ b/stories/0-Single.stories.js
@@ -37,6 +37,24 @@ export const Search = () => (
     />
 );
 
+export const SearchWithEmptyMessage = () => (
+    <SelectSearch
+        options={countries}
+        search
+        emptyMessage="Not found"
+        placeholder="Select your country"
+    />
+);
+
+export const SearchWithEmptyMessageRenderer = () => (
+    <SelectSearch
+        options={countries}
+        search
+        emptyMessage={() => <div style={{ textAlign: 'center', fontSize: '0.8em' }}>Not found renderer</div>}
+        placeholder="Select your country"
+    />
+);
+
 export const AlwaysOpen = () => (
     <SelectSearch
         options={[


### PR DESCRIPTION
Now, you can specify empty options message, very useful feature in search case.

Control the message via new property `emptyMessage`. This prop can be a string or a render function.

All tests pass. Readme updated.
