### PR TITLE
fix: render item elements as buttons, not submits

### DIFF
--- a/__tests__/__snapshots__/SelectSearch.test.jsx.snap
+++ b/__tests__/__snapshots__/SelectSearch.test.jsx.snap
@@ -1374,6 +1374,7 @@ exports[`Test SelectSearch component Focus displays options 2`] = `
               onKeyPress={[Function]}
               onMouseDown={[Function]}
               tabIndex="-1"
+              type="button"
               value="foo"
             >
               Foo
@@ -1415,6 +1416,7 @@ exports[`Test SelectSearch component Focus displays options 2`] = `
               onKeyPress={[Function]}
               onMouseDown={[Function]}
               tabIndex="-1"
+              type="button"
               value="bar"
             >
               Bar
@@ -2191,6 +2193,7 @@ exports[`Test SelectSearch component Renders with multiple 1`] = `
           onKeyPress={[Function]}
           onMouseDown={[Function]}
           tabIndex="-1"
+          type="button"
           value="foo"
         >
           Foo
@@ -2210,6 +2213,7 @@ exports[`Test SelectSearch component Renders with multiple 1`] = `
           onKeyPress={[Function]}
           onMouseDown={[Function]}
           tabIndex="-1"
+          type="button"
           value="bar"
         >
           Bar
@@ -2296,6 +2300,7 @@ exports[`Test SelectSearch component Renders with search and multiple 1`] = `
           onKeyPress={[Function]}
           onMouseDown={[Function]}
           tabIndex="-1"
+          type="button"
           value="foo"
         >
           Foo
@@ -2315,6 +2320,7 @@ exports[`Test SelectSearch component Renders with search and multiple 1`] = `
           onKeyPress={[Function]}
           onMouseDown={[Function]}
           tabIndex="-1"
+          type="button"
           value="bar"
         >
           Bar
@@ -2480,6 +2486,7 @@ exports[`Test SelectSearch component Value change works without onChange handler
               onKeyPress={[Function]}
               onMouseDown={[Function]}
               tabIndex="-1"
+              type="button"
               value="foo"
             >
               Foo
@@ -2521,6 +2528,7 @@ exports[`Test SelectSearch component Value change works without onChange handler
               onKeyPress={[Function]}
               onMouseDown={[Function]}
               tabIndex="-1"
+              type="button"
               value="bar"
             >
               Bar

--- a/dist/cjs/SelectSearch.js
+++ b/dist/cjs/SelectSearch.js
@@ -210,6 +210,7 @@ SelectSearch.defaultProps = {
       /*#__PURE__*/
       // eslint-disable-next-line react/button-has-type
       _react["default"].createElement("button", _extends({
+        type: "button",
         className: className
       }, domProps), option.name)
     );

--- a/dist/cjs/lib/getDisplayValue.js
+++ b/dist/cjs/lib/getDisplayValue.js
@@ -7,7 +7,7 @@ function getDisplayValue(value) {
   if (value && typeof value === 'object') {
     if (Array.isArray(value)) {
       return value.map(function (singleOption) {
-        return singleOption.name;
+        return singleOption && singleOption.name;
       }).join(', ');
     }
 

--- a/dist/esm/SelectSearch.js
+++ b/dist/esm/SelectSearch.js
@@ -186,6 +186,7 @@ SelectSearch.defaultProps = {
   /*#__PURE__*/
   // eslint-disable-next-line react/button-has-type
   React.createElement("button", _extends({
+    type: "button",
     className: className
   }, domProps), option.name),
   renderGroupHeader: name => name,

--- a/dist/esm/lib/getDisplayValue.js
+++ b/dist/esm/lib/getDisplayValue.js
@@ -1,7 +1,7 @@
 export default function getDisplayValue(value) {
   if (value && typeof value === 'object') {
     if (Array.isArray(value)) {
-      return value.map(singleOption => singleOption.name).join(', ');
+      return value.map(singleOption => singleOption && singleOption.name).join(', ');
     }
 
     return value.name;

--- a/src/SelectSearch.jsx
+++ b/src/SelectSearch.jsx
@@ -200,7 +200,7 @@ SelectSearch.defaultProps = {
     closeOnSelect: true,
     renderOption: (domProps, option, snapshot, className) => (
         // eslint-disable-next-line react/button-has-type
-        <button className={className} {...domProps}>
+        <button type="button" className={className} {...domProps}>
             {option.name}
         </button>
     ),


### PR DESCRIPTION
By default options in the Select are rendered as `button` without an `type` attribute, which defaults to `type="submit"`.
Normally it's not a problem, because in most cases Search dropdown is rendered directly in the document body (outside of any forms), but if you choose to use `render="always"` then it starts to be a problem. Then list elements will behave as actual submit buttons. This is very bad.

I've added `type="button"` as this is a proper value in this case.