### PR TITLE
Issue #140, part 2 - Fix issue where input would error out if selected value went missing

### DIFF
--- a/src/lib/isSelected.js
+++ b/src/lib/isSelected.js
@@ -5,7 +5,7 @@ export default function isSelected(itemValue, selectedValue) {
 
     return (
         (Array.isArray(selectedValue))
-            ? selectedValue.findIndex((item) => item.value === itemValue.value) >= 0
+            ? selectedValue.findIndex((item) => item && item.value === itemValue.value) >= 0
             : selectedValue.value === itemValue.value
     );
 }


### PR DESCRIPTION
This is a very similar issue to #140 (fixed by #141), but later in the life cycle.

Scenario:

1. Array of selected values already available
2. Actual options are still waiting for an API call (#141 fixed this leading to the code breaking)
3. Initial API results are displayed with the now available matched values
4. A new API request is made via search, and the previously matched values are missing (This pull request fixes the code breaking)
5. Previously matched values are returned and once again marked as selected

As @tbleckert [mentioned here](https://github.com/tbleckert/react-select-search/pull/141#issuecomment-741615514), this is more of a  patch than it is an actual fix. But still probably worth merging in for the time being, and then keeping in mind for the real solution with `getOption` when used with `getDisplayValue` and `isSelected`.