### PR TITLE
Improve IE11 support

### DIFF
--- a/dist/cjs/lib/flattenOptions.js
+++ b/dist/cjs/lib/flattenOptions.js
@@ -20,5 +20,5 @@ function flattenOptions(options) {
     return _extends({}, option, {
       index: i
     });
-  }).flat();
+  }).reduce((a, b) => a.concat(b), []);
 }

--- a/dist/cjs/lib/flattenOptions.js
+++ b/dist/cjs/lib/flattenOptions.js
@@ -20,5 +20,7 @@ function flattenOptions(options) {
     return _extends({}, option, {
       index: i
     });
-  }).reduce((a, b) => a.concat(b), []);
+  }).reduce(function (a, b) {
+    return a.concat(b);
+  }, []);
 }

--- a/dist/esm/lib/flattenOptions.js
+++ b/dist/esm/lib/flattenOptions.js
@@ -13,5 +13,5 @@ export default function flattenOptions(options) {
     return _extends({}, option, {
       index: i
     });
-  }).flat();
+  }).reduce((a, b) => a.concat(b), []);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13256,8 +13256,7 @@
     "fuse.js": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
-      "dev": true
+      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw=="
     },
     "gauge": {
       "version": "2.7.4",

--- a/src/lib/flattenOptions.js
+++ b/src/lib/flattenOptions.js
@@ -11,5 +11,5 @@ export default function flattenOptions(options) {
         }
 
         return { ...option, index: i };
-    }).flat();
+    }).reduce((a, b) => a.concat(b), []);
 }


### PR DESCRIPTION
IE11 doesn't support `flat` ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat))