### PR TITLE
fix: Solving icon overlay on text

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,7 +39,7 @@
     display: block;
     height: 36px;
     width: 100%;
-    padding: 0 16px;
+    padding: 0 40px 0 16px;
     background: #fff;
     border: 1px solid transparent;
     box-shadow: 0 .0625rem .125rem rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
When the selected text is very large the arrow icon overlay the text

![Screen Shot 2021-04-07 at 2 37 23](https://user-images.githubusercontent.com/26112522/113829004-9ea63980-974a-11eb-9e87-f8ea0e92d886.png)

This PR solving this issue adding more right padding

![Screen Shot 2021-04-07 at 2 40 21](https://user-images.githubusercontent.com/26112522/113829114-bf6e8f00-974a-11eb-82e3-040c345b655f.png)
