### PR TITLE
Allow controlled search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The optionSnapshot is an object that contains the object state: `{ selected: boo
 
 ## Get options
 
-You can fetch options asynchronously with the `getOptions` property. You can either return options directly or through a `Promise`.
+You can fetch options asynchronously with the `getOptions` property. You can either return options directly or through a `Promise`. If a falsy value is returned, options will still be controlled by the `options` prop.
 
 ```jsx
 function getOptions(query) {

--- a/dist/cjs/useFetch.js
+++ b/dist/cjs/useFetch.js
@@ -41,12 +41,15 @@ function useFetch(q, defaultOptions, _ref) {
 
     return (0, _debounce["default"])(function (s) {
       var optionsReq = getOptions(s, defaultOptions);
-      setFetching(true);
-      Promise.resolve(optionsReq).then(function (newOptions) {
-        setOptions((0, _flattenOptions["default"])(filter(newOptions)(s)));
-      })["finally"](function () {
-        return setFetching(false);
-      });
+
+      if (optionsReq) {
+        setFetching(true);
+        Promise.resolve(optionsReq).then(function (newOptions) {
+          setOptions((0, _flattenOptions["default"])(filter(newOptions)(s)));
+        })["finally"](function () {
+          return setFetching(false);
+        });
+      }
     }, debounceTime);
   }, [filterOptions, defaultOptions, getOptions, debounceTime]);
   (0, _react.useEffect)(function () {

--- a/dist/esm/useFetch.js
+++ b/dist/esm/useFetch.js
@@ -17,10 +17,13 @@ export default function useFetch(q, defaultOptions, {
 
     return debounce(s => {
       const optionsReq = getOptions(s, defaultOptions);
-      setFetching(true);
-      Promise.resolve(optionsReq).then(newOptions => {
-        setOptions(flattenOptions(filter(newOptions)(s)));
-      }).finally(() => setFetching(false));
+
+      if (optionsReq) {
+        setFetching(true);
+        Promise.resolve(optionsReq).then(newOptions => {
+          setOptions(flattenOptions(filter(newOptions)(s)));
+        }).finally(() => setFetching(false));
+      }
     }, debounceTime);
   }, [filterOptions, defaultOptions, getOptions, debounceTime]);
   useEffect(() => setOptions(defaultOptions), [defaultOptions]);

--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -18,14 +18,15 @@ export default function useFetch(q, defaultOptions, {
 
         return debounce((s) => {
             const optionsReq = getOptions(s, defaultOptions);
+            if (optionsReq) {
+                setFetching(true);
 
-            setFetching(true);
-
-            Promise.resolve(optionsReq)
-                .then((newOptions) => {
-                    setOptions(flattenOptions(filter(newOptions)(s)));
-                })
-                .finally(() => setFetching(false));
+                Promise.resolve(optionsReq)
+                    .then((newOptions) => {
+                        setOptions(flattenOptions(filter(newOptions)(s)));
+                    })
+                    .finally(() => setFetching(false));
+            }
         }, debounceTime);
     }, [filterOptions, defaultOptions, getOptions, debounceTime]);
 


### PR DESCRIPTION
Prior to version 3 if nothing (as in `null`/`undefined`, not an empty array) was returned for the `getOptions` prop the component would continue to use the values passed in the `options` prop. This is helpful when you want the options to be controlled by your own component rather than managed by the `SelectSearch` component. This update should not affect existing behavior.

Here's a rough example:

```javascript
const Dropdown = ({ default_options }) => {
	const [options, setOptions] = useState(default_options)

	const advancedOptionFunction = (search) => {
		// ...do advanced search things
		const new_option = () => [] // pretend this gets new options
		setOptions(new_options)
	}

	return (
		<SelectSearch
			search
			options={options}
			getOptions={(q) => {
				advancedOptionFunction(q)
				// Note the lack of return. Returning an array or Promise
				// would still act the same as before this pull request
			}}
		/>
	)
}
```