### PR TITLE
Fixed reference to CJS module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "react-select-search",
     "version": "3.0.8",
     "description": "Lightweight select component for React",
-    "main": "dist/esm/index.js",
+    "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "src/index.d.ts",
     "sideEffects": false,


### PR DESCRIPTION
Fixes #172 

The "main" file in package.json pointed to the ESM instead of the CJS module. Which caused node, in situations where ESMs are not supported, to try to load the ESM as a CJS, causing build fails.