### PR TITLE
Add simple default filter options function

### DIFF
--- a/dist/cjs/useFetch.js
+++ b/dist/cjs/useFetch.js
@@ -28,8 +28,10 @@ function useFetch(q, defaultOptions, _ref) {
 
   var fetch = (0, _react.useMemo)(function () {
     var filter = filterOptions || function (op) {
-      return function () {
-        return op;
+      return function (s) {
+        return op.filter(function (o) {
+          return o.name.toLowerCase().includes(s.toLowerCase());
+        });
       };
     };
 

--- a/dist/esm/useFetch.js
+++ b/dist/esm/useFetch.js
@@ -9,7 +9,7 @@ export default function useFetch(q, defaultOptions, {
   const [fetching, setFetching] = useState(false);
   const [options, setOptions] = useState(() => flattenOptions(defaultOptions));
   const fetch = useMemo(() => {
-    const filter = filterOptions || (op => () => op);
+    const filter = filterOptions || (op => s => op.filter(o => o.name.toLowerCase().includes(s.toLowerCase())));
 
     if (!getOptions) {
       return s => setOptions(flattenOptions(filter(defaultOptions)(s)));

--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -10,7 +10,8 @@ export default function useFetch(q, defaultOptions, {
     const [fetching, setFetching] = useState(false);
     const [options, setOptions] = useState(() => flattenOptions(defaultOptions));
     const fetch = useMemo(() => {
-        const filter = filterOptions || ((op) => () => op);
+        const filter = filterOptions
+            || ((op) => (s) => op.filter((o) => o.name.toLowerCase().includes(s.toLowerCase())));
 
         if (!getOptions) {
             return (s) => setOptions(flattenOptions(filter(defaultOptions)(s)));


### PR DESCRIPTION
Currently, if you set the `search` prop to true but do not provide a `filterOptions` function then the entire options list is always returned. I added a simple default filter function that checks if the `search` value is included (case insensitive) anywhere in the `name` value of each option.

Alternatively, we could log an error/warning if `search` is true but `filterOptions` is null.