### PR TITLE
Pass filtered options to useHighlight instead of all options.

### DIFF
--- a/src/useSelect.js
+++ b/src/useSelect.js
@@ -58,15 +58,16 @@ export default function useSelect({
         }, 0);
     };
 
-    const [keyHandlers, highlighted, setHighlighted] = useHighlight(
-        options,
-        onSelect,
-        ref,
-    );
     const middleware = [
         useFuzzySearch ? fuzzySearch : null,
         ...(filterOptions ? filterOptions : []),
     ];
+    const filteredOptions = groupOptions(reduce(middleware, options, q));
+    const [keyHandlers, highlighted, setHighlighted] = useHighlight(
+        filteredOptions,
+        onSelect,
+        ref,
+    );
 
     const snapshot = {
         search: q,
@@ -75,7 +76,7 @@ export default function useSelect({
         value: getValue(option),
         fetching,
         highlighted,
-        options: groupOptions(reduce(middleware, options, q)),
+        options: filteredOptions,
         displayValue: getDisplayValue(option, options, placeholder),
     };
 


### PR DESCRIPTION
This fixes an issue when selecting an option from a filtered list of option using the keyboard (e.g.: Pressing Enter)
It would result in an incorrect selection.

Mentioned in #264 and #258 